### PR TITLE
Nuke custom regex based getFormattedKernelVersion() method

### DIFF
--- a/src/com/android/settings/deviceinfo/KernelVersionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/KernelVersionPreferenceController.java
@@ -22,8 +22,6 @@ import com.android.settings.core.PreferenceControllerMixin;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -50,7 +48,7 @@ public class KernelVersionPreferenceController extends AbstractPreferenceControl
     @Override
     public void updateState(Preference preference) {
         super.updateState(preference);
-        preference.setSummary(getFormattedKernelVersion());
+        preference.setSummary(DeviceInfoUtils.getFormattedKernelVersion());
         preference.setEnabled(true);
     }
 
@@ -98,44 +96,4 @@ public class KernelVersionPreferenceController extends AbstractPreferenceControl
         }
     }
 
-    public static String getFormattedKernelVersion() {
-        try {
-            return formatKernelVersion(readLine(FILENAME_PROC_VERSION));
-
-        } catch (IOException e) {
-            Log.e(LOG_TAG,
-                "IO Exception when getting kernel version for Device Info screen",
-                e);
-
-            return "Unavailable";
-        }
-    }
-
-    public static String formatKernelVersion(String rawKernelVersion) {
-        // Example (see tests for more):
-        // Linux version 3.0.31-g6fb96c9 (android-build@xxx.xxx.xxx.xxx.com) \
-        //     (gcc version 4.6.x-xxx 20120106 (prerelease) (GCC) ) #1 SMP PREEMPT \
-        //     Thu Jun 28 11:02:39 PDT 2012
-
-        final String PROC_VERSION_REGEX =
-            "Linux version (\\S+) " + /* group 1: "3.0.31-g6fb96c9" */
-            "\\((\\S+?)\\) " +        /* group 2: "x@y.com" (kernel builder) */
-            "(?:\\(gcc.+? \\)) " +    /* ignore: GCC version information */
-            "(#\\d+) " +              /* group 3: "#1" */
-            "(?:.*?)?" +              /* ignore: optional SMP, PREEMPT, and any CONFIG_FLAGS */
-            "((Sun|Mon|Tue|Wed|Thu|Fri|Sat).+)"; /* group 4: "Thu Jun 28 11:02:39 PDT 2012" */
-
-        Matcher m = Pattern.compile(PROC_VERSION_REGEX).matcher(rawKernelVersion);
-        if (!m.matches()) {
-            Log.e(LOG_TAG, "Regex did not match on /proc/version: " + rawKernelVersion);
-            return "Unavailable";
-        } else if (m.groupCount() < 4) {
-            Log.e(LOG_TAG, "Regex match on /proc/version only returned " + m.groupCount()
-                    + " groups");
-            return "Unavailable";
-        }
-        return m.group(1) + "\n" +                 // 3.0.31-g6fb96c9
-            m.group(2) + " " + m.group(3) + "\n" + // x@y.com #1
-            m.group(4);                            // Thu Jun 28 11:02:39 PDT 2012
-    }
 }


### PR DESCRIPTION
The provided regex only matches with kernels compiled with GCC, and fails with kernels
compiled with clang. Hence use the stock getFormattedKernelVersion() method.

Change-Id: Id21ae5b639cd038c008a2c134ad87becb02e587a
Signed-off-by: Shubham Singh <coolsks94@gmail.com>