### PR TITLE
Make aosp theme selector unavailable

### DIFF
--- a/src/com/android/settings/display/ThemePreferenceController.java
+++ b/src/com/android/settings/display/ThemePreferenceController.java
@@ -170,9 +170,10 @@ public class ThemePreferenceController extends AbstractPreferenceController impl
 
     @Override
     public boolean isAvailable() {
-        if (mOverlayService == null) return false;
-        String[] themes = getAvailableThemes();
-        return themes != null && themes.length > 1;
+        //if (mOverlayService == null) return false;
+        //String[] themes = getAvailableThemes();
+        //return themes != null && themes.length > 1;
+        return false;
     }
 
 


### PR DESCRIPTION
Since we have custom AccentPicker (Fruity pebbles) from DU

Change-Id: I8d3b07f3a013966f835fad10362c4f402589afb6